### PR TITLE
Update the donate page to link to the correct OpenCollective org

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -3,15 +3,28 @@ layout: default
 title: Donate to Code for DC
 ---
 
-<div class="use-grid-wide" style="margin-top:1rem;">
+<div class="use-grid-wide" style="margin-top: 1rem">
   <div class="usa-width-one-half usa-offset-one-fourth usa-section">
     <h1>Donate to Code for DC</h1>
-    <p>Thank you for your interest in helping to support Code for DC! Contributions of any size are helpful and welcome.</p>
-    <p>Donations to Code for DC are processed via <a href="https://opencollective.com/code-for-dc">Open Collective</a>, a platform where communities can collect and disburse money transparently, to sustain and grow their projects. Code for DC is hosted by the Open Collective Foundation 501(c)(3), and all donations are tax-deductible to the fullest extent of U.S. law.</p>
-    <div style="text-align:center">
-        <a href="https://opencollective.com/code-for-dc/donate" target="_blank">
-          <img src="https://opencollective.com/code-for-dc/donate/button@2x.png?color=blue" width=300 />
-        </a>
+    <p>
+      Thank you for your interest in helping to support Code for DC!
+      Contributions of any size are helpful and welcome.
+    </p>
+    <p>
+      Donations to Code for DC are processed via
+      <a href="https://opencollective.com/civic-tech-dc">Open Collective</a>, a
+      platform where communities can collect and disburse money transparently,
+      to sustain and grow their projects. Code for DC is hosted by the Open
+      Collective Foundation 501(c)(3), and all donations are tax-deductible to
+      the fullest extent of U.S. law.
+    </p>
+    <div style="text-align: center">
+      <a href="https://opencollective.com/civic-tech-dc/donate" target="_blank">
+        <img
+          src="https://opencollective.com/civic-tech-dc/donate/button@2x.png?color=blue"
+          width="300"
+        />
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This broke when we renamed the OpenCollective organization from Code for DC to Civic Tech DC

Demo: 
https://github.com/civictechdc/codefordc-website/assets/9039672/2519aa2a-7404-4128-913d-001e65aeeb32

