### PR TITLE
Fix for logo mobile layout bug

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,7 +95,7 @@
     <header class="usa-header usa-header-basic" role="banner">
       <div class="usa-nav-container">
         <div class="usa-navbar">
-          <a href="/" title="Home" aria-label="Home">
+          <a id="logo-link" href="/" title="Home" aria-label="Home">
             <img
               id="logo"
               src="/images/logo/civic-tech-dc-logo-text-bottom.png"

--- a/css_new/main.css
+++ b/css_new/main.css
@@ -41,6 +41,15 @@ img#logo {
   max-height: 11rem;
 }
 
+#logo-link {
+  display: inline-block;
+}
+
+.usa-navbar {
+  min-height: 4rem;
+  height: initial;
+}
+
 
 #hero-image {
   /* background-image: url("../assets/aa.png"); */

--- a/css_new/uswds.css
+++ b/css_new/uswds.css
@@ -3849,13 +3849,9 @@ fieldset {
   overflow: hidden;
 }
 
-#logo-link {
-  display: inline-block;
-}
-
 .usa-navbar {
   border-bottom: 1px solid #aeb0b5;
-  min-height: 4rem;
+  height: 4rem;
 }
 
 @media screen and (min-width: 951px) {

--- a/css_new/uswds.css
+++ b/css_new/uswds.css
@@ -3850,7 +3850,7 @@ fieldset {
 }
 
 #logo-link {
-  display: block;
+  display: inline-block;
 }
 
 .usa-navbar {

--- a/css_new/uswds.css
+++ b/css_new/uswds.css
@@ -3849,9 +3849,13 @@ fieldset {
   overflow: hidden;
 }
 
+#logo-link {
+  display: block;
+}
+
 .usa-navbar {
   border-bottom: 1px solid #aeb0b5;
-  height: 4rem;
+  min-height: 4rem;
 }
 
 @media screen and (min-width: 951px) {


### PR DESCRIPTION
This addresses the bug where on small devices, the logo in the header overflows the header.

This fixed the issue in dev tools, but I haven't actually tested it yet in the site b/c I haven't gotten it running locally yet. So WIP!

Also, the look isn't great so we might want to resize either the logo or menu button on mobile.