### PR TITLE
Update code-of-conduct.md, with new email address in x2 places in file.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -55,7 +55,7 @@ Please be aware that in order to grow and promote our organization, for general 
 
 ### Making a Report
 
-If you are unable to resolve the issue, or are uncomfortable doing so, you should contact a Captain, either in person or electronically. You can email us at <a href="mailto:team@codefordc.org">team@codefordc.org</a>, which goes to all of the leadership team. Captains agree to keep information shared in association with a Code of Conduct violation private, and may reveal it only with the approval of the affected person(s).
+If you are unable to resolve the issue, or are uncomfortable doing so, you should contact a Captain, either in person or electronically. You can email us at team@civictechdc.org, which goes to all of the leadership team. Captains agree to keep information shared in association with a Code of Conduct violation private, and may reveal it only with the approval of the affected person(s).
 
 When making a report, the following information is useful, but not required:
 
@@ -73,4 +73,4 @@ Captains may take any appropriate action, including expulsion and a ban from fut
 
 ## Contributing to This Code
 
-This is a living document and is ultimately owned by the Civic Tech DC community. We are interested in your comments and suggestions! You can contribute to the code by opening an issue or pull request on this [repository](https://github.com/civictechdc/codefordc-website) or by [contacting the leadership team](mailto:team@codefordc.org).
+This is a living document and is ultimately owned by the Civic Tech DC community. We are interested in your comments and suggestions! You can contribute to the code by opening an issue or pull request on this [repository](https://github.com/civictechdc/codefordc-website) or by contacting the leadership team at team@civictechdc.org.


### PR DESCRIPTION
Update code-of-conduct.md, with new email address in x2 places in file:

This addresses issue:
https://github.com/civictechdc/codefordc-website/issues/54 for code of conduct file.

Chose to remove hyperlink functionality in email address for cyber security purposes - please advise. Thank you.